### PR TITLE
fixing some issues with blocks and languages

### DIFF
--- a/arduino_extension.js
+++ b/arduino_extension.js
@@ -103,7 +103,6 @@
   }
 
   function init() {
-
     for (var i = 0; i < 16; i++) {
       var output = new Uint8Array([REPORT_DIGITAL | i, 0x01]);
       device.send(output.buffer);
@@ -310,6 +309,7 @@
   }
 
   function digitalWrite(pin, val) {
+    console.log('digitalWrite ' + pin + ' -- ' + val);
     if (!hasCapability(pin, OUTPUT)) {
       console.log('ERROR: valid output pins are ' + pinModes[OUTPUT].join(', '));
       return;
@@ -350,9 +350,10 @@
   };
 
   ext.digitalWrite = function(pin, val) {
-    if (val == 'on')
+    console.log('ext.digitalWrite ' + pin + ' -- ' + val);
+    if (val == menus[lang]['outputs'][0])
       digitalWrite(pin, HIGH);
-    else if (val == 'off')
+    else if (val == menus[lang]['outputs'][1])
       digitalWrite(pin, LOW);
   };
 
@@ -428,12 +429,15 @@
 
   ext.digitalLED = function(led, val) {
     var hw = hwList.search(led);
+    console.log('digitlLED ' + led + ' -- ' + hw.pin + ' -- ' + val);
     if (!hw) return;
-    if (val == 'on') {
+    if (val == menus[lang]['outputs'][0]) {
       digitalWrite(hw.pin, HIGH);
+      console.log('digitalLED write ON');
       hw.val = 255;
-    } else if (val == 'off') {
+    } else if (val == menus[lang]['outputs'][1]) {
       digitalWrite(hw.pin, LOW);
+      console.log('digitalLED write OFF');
       hw.val = 0;
     }
   };
@@ -503,6 +507,7 @@
     if (!device) return;
 
     device.open({ stopBits: 0, bitRate: 57600, ctsFlowControl: 0 });
+
     console.log('Attempting connection with ' + device.id);
     device.set_receive_handler(function(data) {
       var inputData = new Uint8Array(data);
@@ -604,7 +609,7 @@
       [' ', 'connetti il %m.hwOut al pin %n', 'connectHW', 'led A', 3],
       [' ', 'connetti il %m.hwIn ad analog %n', 'connectHW', 'potenziometro', 0],
       ['-'],
-      [' ', '%m.outputs il %m.leds', 'digitalLED', 'led A', 'on'],
+      [' ', 'imposta %m.leds a %m.outputs', 'digitalLED', 'led A', 'acceso'],
       [' ', 'porta luminosità di %m.leds a %n%', 'setLED', 'led A', 100],
       [' ', 'cambia luminosità di %m.leds a %n%', 'changeLED', 'led A', 20],
       ['-'],
@@ -617,7 +622,7 @@
       ['h', 'quando %m.hwIn %m.ops %n%', 'whenInput', 'potenziometro', '>', 50],
       ['r', 'leggi %m.hwIn', 'readInput', 'potenziometro'],
       ['-'],
-      [' ', 'porta pin %n a %m.outputs', 'digitalWrite', 1, 'acceso'],
+      [' ', 'imposta pin %n a %m.outputs', 'digitalWrite', 1, 'acceso'],
       [' ', 'porta pin %n al %n%', 'analogWrite', 3, 100],
       ['-'],
       ['h', 'quando pin %n è %m.outputs', 'whenDigitalRead', 1, 'acceso'],


### PR DESCRIPTION
hi khanning,
it is few days I am using your great Arduino extension for ScratchX.

I am an Italian user but I can read/write English. However I am interested to use your extension with Italian kids which don't speak English.
For this reason I have started to use your extension in Italian language (&language=it)
However it was not working for me.

For this reason I made some fixes and now it works for me.

if you consider it correct I would appreciate if you can merge with your master branch.

In short the issue I have found (only looked at digitalWrite and digitalLED) is that when checking val == 'on' or val =='off' this is always not executed as the to val variable it is assigned a value in translated language (in my case Italian)

so something like if (val == 'on') would become if ('acceso' == 'on)
which is obviously false.

so my solution is to check val again the menus[lang]['outputs'] array and not against hard coded values.

hope this is correct :)

if you are ok with that I will continue to test it in Italian and if something else will not work I will fix it.

thank you so much
Antonio

PS: you have done a great job!!! :)
